### PR TITLE
Fix FilterException indexing bug

### DIFF
--- a/Runtime/Exceptions/FilterException.cs
+++ b/Runtime/Exceptions/FilterException.cs
@@ -40,7 +40,7 @@ namespace Massive
 			{
 				for (var j = 0; j < setsB.Length; j++)
 				{
-					if (setsA[i] != null && setsB[i] != null && setsA[i] == setsB[i])
+					if (setsA[i] != null && setsB[j] != null && setsA[i] == setsB[j])
 					{
 						throw new FilterException($"Query has conflicting {Name(typeA)} and {Name(typeB)} components.");
 


### PR DESCRIPTION
There is a small bug in filters.
The repro can be found by using a filter with more includes than excludes:
`World.Include<A, B>().Exclude<C>()`.